### PR TITLE
feature: MUI theme and color scheme button toggle

### DIFF
--- a/src/components/ui/ColorModeToggle.jsx
+++ b/src/components/ui/ColorModeToggle.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import {useColorScheme} from '@mui/material/styles';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import LightModeRoundedIcon from '@mui/icons-material/LightModeRounded';
+import DarkModeRoundedIcon from '@mui/icons-material/DarkModeRounded';
+
+export default function ColorModeToggle(props) {
+  const {mode, setMode} = useColorScheme();
+
+  const toggle = () => {
+    const next = mode === 'light' ? 'dark' : 'light';
+    setMode(next);
+  };
+
+  const title = mode === 'light' ? 'Passer en mode sombre' : 'Passer en mode clair';
+
+  return (
+    <Tooltip title={title} arrow>
+      <IconButton color="inherit" onClick={toggle} {...props}>
+        {mode === 'light' ? <DarkModeRoundedIcon/> : <LightModeRoundedIcon/>}
+      </IconButton>
+    </Tooltip>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,17 @@ import {StrictMode} from 'react'
 import {createRoot} from 'react-dom/client'
 import {router} from './routes.js'
 import {AuthProvider} from "./context/AuthContext.jsx";
+import {ThemeProvider} from "@mui/material/styles";
+import {appTheme} from "./theme.js";
+import CssBaseline from "@mui/material/CssBaseline";
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <AuthProvider>
-      <RouterProvider router={router}/>
+      <ThemeProvider theme={appTheme} defaultMode={"system"}>
+        <CssBaseline />
+        <RouterProvider router={router}/>
+      </ThemeProvider>
     </AuthProvider>
   </StrictMode>,
 )

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Typography, Button, Stack } from '@mui/material';
 import SchoolIcon from '@mui/icons-material/School';
 import { Link } from 'react-router';
+import ColorModeToggle from "../components/ui/ColorModeToggle.jsx";
 
 export default function Home() {
   return (
@@ -45,6 +46,8 @@ export default function Home() {
         >
           Parcourir les fiches
         </Button>
+
+        <ColorModeToggle />
       </Stack>
     </Box>
   );

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,33 @@
+import {createTheme} from '@mui/material/styles';
+
+export const appTheme = createTheme({
+  colorSchemes: {
+    dark: true,
+  },
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#2E7D32',
+    },
+    background: {
+      default: '#F9FAFB',
+      paper: '#FFFFFF',
+    },
+  },
+  typography: {
+    fontFamily: '"Roboto","Helvetica","Arial",sans-serif',
+  },
+  components: {
+    // Exemple : arrondis XXL sur tous les Paper
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          borderRadius: '1.5rem',
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
Cette PR ajoute le [theming via Material UI](https://mui.com/material-ui/customization/theming/) sous `src/theme.js` et un bouton permettant de switch entre le mode sombre et light réutilisable: `ColorModeToggle`