### PR TITLE
Patch_GestionFlashcards_reset_add_flashcards

### DIFF
--- a/src/components/flashcards/Gestionflashcard.jsx
+++ b/src/components/flashcards/Gestionflashcard.jsx
@@ -72,6 +72,7 @@ export default function FlashcardGestion() {
         console.error("L'envoi n'a pas marché :", await reponse.text());
       }
     }
+    setFlashcards([]);
     setAlertOpen(true);
     } 
     catch (error) {


### PR DESCRIPTION
Cette PR concerne uniquement un patch dans gestionflashcards.jsx qui :

Reset la liste des flashcards ajouté, lorsqu'on clique sur envoyer les flashcards.