### PR TITLE
Patch_flashcard_update_mardowneditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,17 @@
     "@mui/material": "^7.1.2",
     "@uiw/react-md-editor": "^4.0.7",
     "axios": "^1.10.0",
+    "hast-util-sanitize": "^5.0.2",
     "katex": "^0.16.22",
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-markdown": "^10.1.0",
     "react-router": "^7.6.2",
-    "react-toastify": "^11.0.5"
+    "react-toastify": "^11.0.5",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/components/flashcards/flashcard.jsx
+++ b/src/components/flashcards/flashcard.jsx
@@ -5,104 +5,121 @@ import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import MDEditor from "@uiw/react-md-editor";
 
-export default function OutlinedCard({ sujet, niveau, theme, description_recto, description_verso }) {
+// yarn add react-markdown remark-gfm rehype-raw rehype-sanitize hast-util-sanitize 
+// (librairies pour le rendu markdown compatible avec MDXEditor)
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
+import { defaultSchema } from 'hast-util-sanitize';
+
+// schema du style sur <mark> & <span> 
+const schema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    mark: [...(defaultSchema.attributes?.mark || []), 'style'],
+    span: [...(defaultSchema.attributes?.span || []), 'style'],
+  },
+};
+// fonction permettant de visualiser le markdown en prenant en compte la source et appliquant le schema
+function MarkdownViewer({ source }) {
+  return (
+    <ReactMarkdown
+      children={source}
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw, [rehypeSanitize, schema]]}
+      components={{
+        span: ({ node, ...props }) => <span {...props} />, // Utilisation de span pour le style (le style <mark> pose trop de problème -> à cause des selctions dans le texte)
+      }}
+    />
+  );
+}
+export default function OutlinedCard({
+  sujet,
+  niveau,
+  theme,
+  description_recto,
+  description_verso,
+}) {
   const [isFlipped, setIsFlipped] = useState(false);
+  const handleFlip = () => setIsFlipped((p) => !p); //Inverse l'état de la carte
 
-  const handleFlip = () => {
-    setIsFlipped(prev => !prev); //Inverse l'état de la carte
-  };
+  const scrollBox = { mt: 1, maxHeight: 185, overflowY: 'auto' };
 
   return (
-    <Box sx={{ perspective: '1000px', width: 300, height: 300 }}>  
+    <Box sx={{ perspective: 1000, width: 300, height: 300 }}>
       <Box
         sx={{
           position: 'relative',
           width: '100%',
           height: '100%',
-          display: 'flex',
-          margin: 0,
-          justifyContent: 'center',
-          padding: "2px 2px 3px 0px",
           transition: 'transform 0.6s',
           transformStyle: 'preserve-3d',
           transform: isFlipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
         }}
       >
-        {/* Recto */}
+        {/* -------- Recto -------- */}
         <Card
           variant="outlined"
           sx={{
             position: 'absolute',
-            width: '100%',
-            height: '100%',
+            inset: 0,
             backfaceVisibility: 'hidden',
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'space-between',
-            padding: 2,
+            p: 2,
           }}
         >
-          <CardContent sx={{ padding: '0px' }}>
+          <CardContent sx={{ p: 0 }}>
             <Typography gutterBottom sx={{ color: 'text.secondary', fontSize: 20 }}>
               {sujet}
             </Typography>
-            <Typography variant="h5" component="div">
-              {niveau} <Box component="span" sx={{ mx: '2px' }}>•</Box> {theme}
+            <Typography variant="h5">
+              {niveau} <Box component="span" sx={{ mx: 1 }}>•</Box> {theme}
             </Typography>
-            <Box sx={{ mt: 1, maxHeight: '185px', overflowY: 'scroll'}}>
-              <MDEditor.Markdown source={description_recto || 'Description non fournie.'} 
-              style={{
-                backgroundColor: 'transparent',
-                color: '#000',
-                whiteSpace: 'pre-wrap' 
-                }}/>
+            <Box sx={scrollBox}>
+              <MarkdownViewer source={description_recto || 'Description non fournie.'} />
             </Box>
           </CardContent>
-          <CardActions sx={{ justifyContent: 'flex-start' }}>
-            {description_verso && (
-            <Button size="small" onClick={handleFlip} sx={{margin: '-9px'}}>Voir le verso</Button>
-            )}
-          </CardActions>
+
+          {description_verso && (
+            <CardActions sx={{ p: 0 }}>
+              <Button size="small" onClick={handleFlip}>Voir le verso</Button>
+            </CardActions>
+          )}
         </Card>
 
-        {/* Verso */}
+        {/* -------- Verso -------- */}
         <Card
           variant="outlined"
           sx={{
             position: 'absolute',
-            width: '100%',
-            height: '100%',
+            inset: 0,
             backfaceVisibility: 'hidden',
             transform: 'rotateY(180deg)',
             display: 'flex',
             flexDirection: 'column',
             justifyContent: 'space-between',
-            padding: 2,
-            margin: 0
+            p: 2,
           }}
         >
-          <CardContent sx={{ padding: '0px' }}>
+          <CardContent sx={{ p: 0 }}>
             <Typography gutterBottom sx={{ color: 'text.secondary', fontSize: 20 }}>
               {sujet}
             </Typography>
-            <Typography variant="h5" component="div">
-              {niveau} <Box component="span" sx={{ mx: '2px' }}>•</Box> {theme}
+            <Typography variant="h5">
+              {niveau} <Box component="span" sx={{ mx: 1 }}>•</Box> {theme}
             </Typography>
-            <Box sx={{ mt: 1, maxHeight: '185px', overflowY: 'scroll' }}>
-            <MDEditor.Markdown
-            source={description_verso || 'Description non fournie.'}
-            style={{
-            backgroundColor: 'transparent',
-            color: '#000',
-            whiteSpace: 'pre-wrap',
-            }}
-            />
-          </Box>
+            <Box sx={scrollBox}>
+              <MarkdownViewer source={description_verso || 'Description non fournie.'} />
+            </Box>
           </CardContent>
-          <CardActions sx={{ justifyContent: 'flex-start' }}>
-            <Button size="small" onClick={handleFlip} sx={{margin: '-9px'}}>Retourner</Button>
+
+          <CardActions sx={{ p: 0 }}>
+            <Button size="small" onClick={handleFlip}>Retourner</Button>
           </CardActions>
         </Card>
       </Box>

--- a/src/components/shared/MarkdownEditor.jsx
+++ b/src/components/shared/MarkdownEditor.jsx
@@ -1,81 +1,224 @@
+import React, { useRef, forwardRef, useImperativeHandle } from 'react'
 import {
-  BlockTypeSelect,
-  BoldItalicUnderlineToggles,
+  MDXEditor,
+  headingsPlugin,
   codeBlockPlugin,
   codeMirrorPlugin,
-  CodeToggle,
-  ConditionalContents,
-  CreateLink,
+  quotePlugin,
+  listsPlugin,
+  thematicBreakPlugin,
   diffSourcePlugin,
-  DiffSourceToggleWrapper,
-  headingsPlugin,
   imagePlugin,
+  tablePlugin,
+  linkDialogPlugin,
+  toolbarPlugin,
+  BlockTypeSelect,
+  BoldItalicUnderlineToggles,
+  CreateLink,
+  InsertTable,
   InsertCodeBlock,
   InsertImage,
-  InsertTable,
   InsertThematicBreak,
-  linkDialogPlugin,
-  listsPlugin,
   ListsToggle,
-  MDXEditor,
-  quotePlugin,
-  Separator,
-  tablePlugin,
-  thematicBreakPlugin,
-  toolbarPlugin,
   UndoRedo,
+  Separator,
+  ConditionalContents,
+  CodeToggle,
+  DiffSourceToggleWrapper,
+  jsxPlugin
 } from '@mdxeditor/editor'
 import '@mdxeditor/editor/style.css'
+import { Button, Menu, MenuItem, ListItemIcon,ListItemText,Tooltip, IconButton } from '@mui/material'
+import FormatColorFillIcon from '@mui/icons-material/FormatColorFill'
+import PaletteIcon         from '@mui/icons-material/Palette';
 
+const ListeColor = [
+  { label: 'Aucun',  hex: null },
+  { label: 'Jaune',  hex: '#FFFF00' },
+  { label: 'Orange', hex: '#FFA500' },
+  { label: 'Rouge',  hex: '#FF0000' },
+  { label: 'Vert',   hex: '#008000' },
+  { label: 'Bleu',   hex: '#0000FF' },
+  { label: 'Violet', hex: '#800080' },
+  { label: 'Gris',   hex: '#808080' }
+];
 
-const plugins = [
-  headingsPlugin(),
-  codeBlockPlugin({defaultCodeBlockLanguage: 'js'}),
-  codeMirrorPlugin({
-    codeBlockLanguages: {js: 'JavaScript', ts: 'TypeScript', css: 'CSS'}
-  }),
-  quotePlugin(),
-  listsPlugin(),
-  thematicBreakPlugin(),
-  diffSourcePlugin(),
-  imagePlugin(),
-  tablePlugin(),
-  linkDialogPlugin(),
+// Fonction pour fusionner les styles
+// (ajoute ou modifie une propriété CSS dans un style existant)
 
-  toolbarPlugin({
-    toolbarContents: () => (
-      <ConditionalContents
-        options={[
-          {
-            when: (editor) => editor?.editorType === 'codeblock',
-            contents: () => <CodeToggle/>
-          },
-          {
-            fallback: () => (
-              <>
-                <UndoRedo/>
-                <BlockTypeSelect/>
-                <Separator/>
-                <BoldItalicUnderlineToggles/>
-                <InsertThematicBreak/>
-                <Separator/>
-                <CreateLink/>
-                <InsertTable/>
-                <InsertCodeBlock/>
-                <InsertImage/>
-                <Separator/>
-                <ListsToggle/>
-                <Separator/>
-                <DiffSourceToggleWrapper/>
-              </>
-            )
-          }
-        ]}
-      />
-    )
-  })
-]
-
-export default function MarkdownEditor({ref}) {
-  return <MDXEditor ref={ref} markdown="# Hello world" plugins={plugins}/>
+function mergeStyle(oldStyle = '', prop, value) {
+  const styles = {};
+  oldStyle      // ← oldStyle vaut maintenant toujours une string
+    .split(';')
+    .forEach(pair => {
+      const [k, v] = pair.split(':').map(s => s.trim()).filter(Boolean);
+      if (k && v) styles[k] = v;
+    }); 
+  if (value === null) delete styles[prop];
+  else styles[prop] = value; 
+  return Object.entries(styles)
+               .map(([k, v]) => `${k}:${v}`)
+               .join('; ');
 }
+// fonction pour appliquer un style à la sélection courante
+// (ajoute ou modifie une propriété CSS dans un span autour de la sélection)
+function applyStyle(selObj, prop, val, editorRef) {
+  const text = selObj?.toString();
+  if (!text) return false;
+
+  const span = selObj.anchorNode?.parentElement?.closest('span');
+  let html;
+
+  if (span) {
+    const merged = mergeStyle(span.getAttribute('style') || '', prop, val);
+    html = merged
+      ? `<span style="${merged}">${text}</span>`
+      : text;                        // plus aucun style -> enlève la balise
+  } else if (val !== null) {
+    html = `<span style="${prop}:${val};">${text}</span>`;
+  } else {
+    // « Aucun » alors qu'il n'y avait pas ce style
+    return false;
+  }
+
+  editorRef.current.insertMarkdown(html + ' ');
+  return true;
+}
+
+// fonction pour le bouton de menu de couleur 
+function ColorMenuButton({ icon, tooltip, cssProp, editorRef, sx }) {
+  const [anchor, setAnchor] = React.useState(null);
+  const open  = e => setAnchor(e.currentTarget);
+  const close = () => setAnchor(null);
+
+  const clickColor = (hex) => {
+    if (!editorRef.current) return;
+
+    // bug sur les texte de type "titre" (h1, h2, etc.) : methode pour empecher un disfonctionnement 
+    // A retravailler
+    const selObj = window.getSelection();
+    const headingAncestor =
+    selObj?.anchorNode?.parentElement?.closest('h1,h2,h3,h4,h5,h6');
+
+  if (headingAncestor && selObj.anchorOffset === 0) {
+    close();                    // on ferme le menu, on ne fait rien
+    return;
+  }
+    editorRef.current.focus?.();
+
+    const ok = applyStyle(window.getSelection(), cssProp, hex, editorRef);
+    if (ok) close();
+  };
+
+  return (
+    <>
+      <Tooltip title={tooltip}>
+        <IconButton size="small" onClick={open} sx={sx}>{icon}</IconButton>
+      </Tooltip>
+
+      <Menu anchorEl={anchor} open={Boolean(anchor)} onClose={close}>
+        {ListeColor.map(({ label, hex }) => (
+          <MenuItem key={label} onClick={() => clickColor(hex)}>
+            <ListItemIcon>
+              <span style={{
+                display:'inline-block', width:16, height:16,
+                backgroundColor: hex ?? 'transparent',
+                border:'1px solid #ccc', borderRadius:3
+              }}/>
+            </ListItemIcon>
+            <ListItemText>{label}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}
+
+// fonction pour insérer un surlignage
+export function InsertSurlignage({ editorRef }) {
+  return (
+    <ColorMenuButton
+      icon={<FormatColorFillIcon fontSize="small" />}
+      tooltip="Surligner"
+      cssProp="background-color"
+      editorRef={editorRef}
+    />
+  );
+}
+// fonction pour insérer une couleur de texte
+export function InsertTextColor({ editorRef }) {
+  return (
+    <ColorMenuButton
+      icon={<PaletteIcon fontSize="small" />}
+      tooltip="Couleur texte"
+      cssProp="color"
+      editorRef={editorRef}
+      sx={{ ml: 1 }}
+    />
+  );
+}
+
+export default forwardRef(function MarkdownEditor(props, ref) {
+  const editorRef = useRef(null)
+
+  useImperativeHandle(ref, () => ({
+    getMarkdown: () => editorRef.current?.getMarkdown(),
+    setMarkdown: (md) => editorRef.current?.setMarkdown(md)
+  }), [])
+
+  const plugins = [
+    headingsPlugin(),
+    codeBlockPlugin({ defaultCodeBlockLanguage: 'js' }),
+    codeMirrorPlugin({ codeBlockLanguages: { js: 'JavaScript', ts: 'TypeScript', css: 'CSS' } }),
+    quotePlugin(),
+    listsPlugin(),
+    thematicBreakPlugin(),
+    diffSourcePlugin(),
+    imagePlugin(),
+    tablePlugin(),
+    linkDialogPlugin(),
+    toolbarPlugin({
+      toolbarContents: () => (
+        <ConditionalContents
+          options={[
+            {
+              when: (editor) => editor?.editorType === 'codeblock',
+              contents: () => <CodeToggle />
+            },
+            {
+              fallback: () => (
+                <>
+                  <UndoRedo />
+                  <BlockTypeSelect />
+                  <Separator />
+                  <BoldItalicUnderlineToggles />
+                  <InsertThematicBreak />
+                  <Separator />
+                  <CreateLink />
+                  <InsertTable />
+                  <InsertCodeBlock />
+                  <InsertImage />
+                  <Separator />
+                  <InsertSurlignage editorRef={editorRef}/>
+                  <InsertTextColor editorRef={editorRef}/>
+                  <Separator />
+                  <ListsToggle />
+                  <Separator />
+                  <DiffSourceToggleWrapper />
+                </>
+              )
+            }
+          ]}
+        />
+      )
+    })
+  ]
+
+  return (
+    <MDXEditor
+      ref={editorRef}
+      markdown={props.markdown || '# Hello world'}
+      plugins={plugins}
+    />
+  )
+})


### PR DESCRIPTION
Cette PR concerne :

Un patch sur la flaschards.jsx permettant d'avoir la view d'une  flashcards avec sont css visible (et sans les balises "<>" qui vont avec) Il faut installer la dependance sur la developp "yarn add react-markdown remark-gfm rehype-raw rehype-sanitize hast-util-sanitize" .


L'ajout de 2 nouvelle fonctionnalité sur la toobar, une qui concerne le change de couleur (défini) du texte et l'autre la surbrillance sur le texte sélectionné via la commande "window.getSelection();".



