### PR TITLE
feature: review session - flashcard mode

### DIFF
--- a/src/components/auth/SignInCard.jsx
+++ b/src/components/auth/SignInCard.jsx
@@ -13,9 +13,8 @@ import {Link as RouterLink, useNavigate} from 'react-router';
 import {AuthContainer} from "../shared/AuthContainer.jsx";
 import {AuthCard} from "../shared/AuthCard.jsx";
 import ForgotPassword from "./ForgotPassword.jsx";
-import {toast, ToastContainer} from 'react-toastify';
+import {toast} from 'react-toastify';
 import {useAuth} from "../../context/AuthContext.jsx";
-import useTheme from '../../hooks/useTheme';
 
 export default function SignInCard() {
   const [emailError, setEmailError] = useState(false);
@@ -25,7 +24,6 @@ export default function SignInCard() {
   const [open, setOpen] = useState(false);
 
   const {login, loading} = useAuth();
-  const currentTheme = useTheme();
   const navigate = useNavigate();
 
   const handleClickOpen = () => {
@@ -71,16 +69,14 @@ export default function SignInCard() {
     const data = new FormData(event.currentTarget);
     try {
       await login(data.get('email'), data.get('password'));
-      toast.success('Connexion réussie!', {
-        position: "bottom-right",
-        theme: currentTheme === 'dark' ? 'dark' : 'light'
-      });
+      toast.success('Connexion réussie!');
       navigate("/");
-    } catch {
-      toast.error('Échec de la connexion. Vérifiez vos identifiants.', {
-        position: "bottom-right",
-        theme: currentTheme === 'dark' ? 'dark' : 'light'
-      });
+    } catch (error) {
+      if (error.response && error.response.status === 401) {
+        toast.error('Identifiants incorrects. Veuillez vérifier votre email et mot de passe.');
+      } else {
+        toast.error('Erreur de connexion. Veuillez réessayer plus tard.');
+      }
     }
   };
 
@@ -173,7 +169,6 @@ export default function SignInCard() {
           </Typography>
         </Box>
       </AuthCard>
-      <ToastContainer/>
     </AuthContainer>
   );
 }

--- a/src/components/auth/SignUpCard.jsx
+++ b/src/components/auth/SignUpCard.jsx
@@ -12,9 +12,8 @@ import Link from '@mui/material/Link';
 import {Link as RouterLink, useNavigate} from 'react-router';
 import {AuthContainer} from "../shared/AuthContainer.jsx";
 import {AuthCard} from "../shared/AuthCard.jsx";
-import {toast, ToastContainer} from 'react-toastify';
+import {toast} from 'react-toastify';
 import {useAuth} from "../../context/AuthContext.jsx";
-import useTheme from '../../hooks/useTheme';
 
 export default function SignUpCard() {
   const [emailError, setEmailError] = useState(false);
@@ -25,7 +24,6 @@ export default function SignUpCard() {
   const [usernameErrorMessage, setUsernameErrorMessage] = useState('');
 
   const {register, loading} = useAuth();
-  const currentTheme = useTheme();
   const navigate = useNavigate();
 
   const validateInputs = () => {
@@ -74,16 +72,10 @@ export default function SignUpCard() {
     const data = new FormData(event.currentTarget);
     try {
       await register(data.get('email'), data.get('password'), data.get('username'));
-      toast.success('Compte créé avec succès!', {
-        position: "bottom-right",
-        theme: currentTheme === 'dark' ? 'dark' : 'light'
-      });
+      toast.success('Compte créé avec succès!');
       navigate("/login");
     } catch {
-      toast.error('Échec de la création du compte. Veuillez réessayer.', {
-        position: "bottom-right",
-        theme: currentTheme === 'dark' ? 'dark' : 'light'
-      });
+      toast.error('Échec de la création du compte. Veuillez réessayer.');
     }
   };
 
@@ -191,7 +183,6 @@ export default function SignUpCard() {
           </Typography>
         </Box>
       </AuthCard>
-      <ToastContainer/>
     </AuthContainer>
   );
 }

--- a/src/components/deck/DeckPreviewCard.jsx
+++ b/src/components/deck/DeckPreviewCard.jsx
@@ -9,7 +9,15 @@ import Button from "@mui/material/Button";
 import EditIcon from "@mui/icons-material/Edit";
 import CardActions from "@mui/material/CardActions";
 
-export default function DeckPreviewCard({deck, showEditButton = false, showMetadata = false}) {
+export default function DeckPreviewCard(
+  {
+    deck,
+    showEditButton = false,
+    showMetadata = false,
+    showSeeButton = true,
+    transition = true
+  }
+) {
 
   const getStatusColor = (status) => {
     switch (status) {
@@ -39,11 +47,13 @@ export default function DeckPreviewCard({deck, showEditButton = false, showMetad
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        transition: 'transform 0.2s, box-shadow 0.2s',
-        '&:hover': {
-          transform: 'translateY(-4px)',
-          boxShadow: 6
-        }
+        ...(transition && {
+          transition: 'transform 0.2s, box-shadow 0.2s',
+          '&:hover': {
+            transform: 'translateY(-4px)',
+            boxShadow: 6
+          }
+        })
       }}
     >
       <CardContent sx={{flexGrow: 1}}>
@@ -78,27 +88,31 @@ export default function DeckPreviewCard({deck, showEditButton = false, showMetad
           />
         </Stack>
       </CardContent>
-      <CardActions>
-        <Button
-          size="small"
-          component={Link}
-          to={`/decks/${deck.id}`}
-          startIcon={<VisibilityIcon/>}
-        >
-          Voir
-        </Button>
-        {showEditButton && (
-          <Button
-            size="small"
-            component={Link}
-            to={`/decks/${deck.id}/edit`}
-            color="primary"
-            startIcon={<EditIcon/>}
-          >
-            Modifier
-          </Button>
-        )}
-      </CardActions>
+      {(showSeeButton || showEditButton) &&
+        <CardActions>
+          {showSeeButton && (
+            <Button
+              size="small"
+              component={Link}
+              to={`/decks/${deck.id}`}
+              startIcon={<VisibilityIcon/>}
+            >
+              Voir
+            </Button>
+          )}
+          {showEditButton && (
+            <Button
+              size="small"
+              component={Link}
+              to={`/decks/${deck.id}/edit`}
+              color="primary"
+              startIcon={<EditIcon/>}
+            >
+              Modifier
+            </Button>
+          )}
+        </CardActions>
+      }
     </Card>
   )
 }

--- a/src/components/flashcards/flashcard.jsx
+++ b/src/components/flashcards/flashcard.jsx
@@ -42,6 +42,7 @@ export default function OutlinedCard({
   theme,
   description_recto,
   description_verso,
+  sx = {},
 }) {
   const [isFlipped, setIsFlipped] = useState(false);
   const handleFlip = () => setIsFlipped((p) => !p); //Inverse l'état de la carte
@@ -71,6 +72,7 @@ export default function OutlinedCard({
             flexDirection: 'column',
             justifyContent: 'space-between',
             p: 2,
+            ...sx
           }}
         >
           <CardContent sx={{ p: 0 }}>

--- a/src/components/flashcards/flashcard.jsx
+++ b/src/components/flashcards/flashcard.jsx
@@ -24,7 +24,7 @@ const schema = {
   },
 };
 // fonction permettant de visualiser le markdown en prenant en compte la source et appliquant le schema
-function MarkdownViewer({ source }) {
+export function MarkdownViewer({ source }) {
   return (
     <ReactMarkdown
       children={source}

--- a/src/components/home/ProgressSection.jsx
+++ b/src/components/home/ProgressSection.jsx
@@ -18,7 +18,7 @@ export default function ProgressSection() {
       <Box mt={2}>
         <Button
           component={Link}
-          to="/flashcards/resume"
+          to="/review-queue"
           variant="contained"
           size="medium"
         >

--- a/src/components/layout/Root.jsx
+++ b/src/components/layout/Root.jsx
@@ -3,8 +3,12 @@ import Box from "@mui/material/Box";
 import Header from "./Header.jsx";
 import {Container} from "@mui/material";
 import Footer from "./Footer.jsx";
+import {ToastContainer} from 'react-toastify';
+import useTheme from "../../hooks/useTheme.js";
+
 
 export default function Root() {
+  const currentTheme = useTheme();
   return (
     <Container sx={{minHeight: '100vh', display: 'flex', flexDirection: 'column'}}>
       <Header/>
@@ -17,6 +21,11 @@ export default function Root() {
       >
         <Outlet/>
       </Box>
+      <ToastContainer
+        position="bottom-right"
+        role="alert"
+        aria-live="polite"
+        theme={currentTheme === 'dark' ? 'dark' : 'light'}/>
       <Footer/>
     </Container>
   );

--- a/src/pages/DeckDetails.jsx
+++ b/src/pages/DeckDetails.jsx
@@ -11,8 +11,7 @@ import SchoolIcon from '@mui/icons-material/School'
 import AddIcon from '@mui/icons-material/Add'
 import OutlinedCard from '../components/flashcards/flashcard.jsx'
 import {useAuth} from '../context/AuthContext'
-import {toast, ToastContainer} from 'react-toastify'
-import useTheme from "../hooks/useTheme.js";
+import {toast} from 'react-toastify'
 import {addToRevisionQueue} from "../api/review.js";
 import {useDocumentTitle} from "../hooks/useDocumentTitle.js";
 import {fetchDeck} from '../api/deck'
@@ -25,8 +24,6 @@ export default function DeckDetails() {
   const [error, setError] = useState(null)
   const {isAuthenticated} = useAuth()
   const [addingToQueue, setAddingToQueue] = useState(false)
-
-  const currentTheme = useTheme();
 
   useDocumentTitle(
     loading
@@ -206,12 +203,6 @@ export default function DeckDetails() {
           </Grid>
         </section>
       </main>
-      <ToastContainer
-        position="bottom-right"
-        role="alert"
-        aria-live="polite"
-        theme={currentTheme === 'dark' ? 'dark' : 'light'}
-      />
     </Container>
   )
 }

--- a/src/pages/DeckForm.jsx
+++ b/src/pages/DeckForm.jsx
@@ -8,10 +8,9 @@ import {useDocumentTitle} from '../hooks/useDocumentTitle.js'
 import MarkdownEditor from '../components/shared/MarkdownEditor.jsx'
 import DeckInfos from '../components/deck/DeckInfos.jsx'
 import OutlinedCard from '../components/flashcards/flashcard.jsx'
-import {toast, ToastContainer} from 'react-toastify';
+import {toast} from 'react-toastify';
 import {createDeck, fetchDeck, updateDeck} from "../api/deck.js";
 import {useNavigate, useParams} from 'react-router';
-import useTheme from "../hooks/useTheme.js";
 import CircularProgress from '@mui/material/CircularProgress';
 
 export default function DeckForm() {
@@ -32,7 +31,6 @@ export default function DeckForm() {
   const [editingId, setEditingId] = useState(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const currentTheme = useTheme();
   const navigate = useNavigate();
 
   /* Fetch deck data when in edit mode */
@@ -62,10 +60,7 @@ export default function DeckForm() {
           setCards(transformedCards);
         } catch (error) {
           console.error("Failed to fetch deck:", error);
-          toast.error('Impossible de charger le deck', {
-            position: "bottom-right",
-            theme: currentTheme === 'dark' ? 'dark' : 'light'
-          });
+          toast.error('Impossible de charger le deck');
         } finally {
           setIsLoading(false);
         }
@@ -73,7 +68,7 @@ export default function DeckForm() {
 
       getDeck();
     }
-  }, [currentTheme, id, isEditMode]);
+  }, [id, isEditMode]);
 
   /* create or update card */
   const handleSaveCard = () => {
@@ -109,10 +104,7 @@ export default function DeckForm() {
   /* send deck */
   const handleSubmitDeck = async () => {
     if (!titre.trim() || cards.length === 0) {
-      toast.error('Veuillez fournir un titre et au moins une fiche avant de soumettre le deck.', {
-        position: "bottom-right",
-        theme: currentTheme === 'dark' ? 'dark' : 'light'
-      })
+      toast.error('Veuillez fournir un titre et au moins une fiche avant de soumettre le deck.')
       return
     }
 
@@ -146,16 +138,10 @@ export default function DeckForm() {
 
       if (isEditMode) {
         response = await updateDeck(id, JSON.stringify(payload));
-        toast.success('Deck mis à jour avec succès !', {
-          position: "bottom-right",
-          theme: currentTheme === 'dark' ? 'dark' : 'light'
-        });
+        toast.success('Deck mis à jour avec succès !');
       } else {
         response = await createDeck(JSON.stringify(payload));
-        toast.success('Deck créé avec succès !', {
-          position: "bottom-right",
-          theme: currentTheme === 'dark' ? 'dark' : 'light'
-        });
+        toast.success('Deck créé avec succès !');
       }
 
       if (response && (response.id || id)) {
@@ -165,10 +151,7 @@ export default function DeckForm() {
       }
     } catch (e) {
       console.error(e)
-      toast.error(`Échec de ${isEditMode ? 'la mise à jour' : 'la création'} du deck. Veuillez réessayer.`, {
-        position: "bottom-right",
-        theme: currentTheme === 'dark' ? 'dark' : 'light'
-      });
+      toast.error(`Échec de ${isEditMode ? 'la mise à jour' : 'la création'} du deck. Veuillez réessayer.`);
     } finally {
       setIsSubmitting(false)
     }
@@ -249,7 +232,6 @@ export default function DeckForm() {
             </Box>
           </Grid>))}
       </Grid>
-      <ToastContainer/>
     </Container>
   )
 }

--- a/src/pages/ReviewQueue.jsx
+++ b/src/pages/ReviewQueue.jsx
@@ -15,10 +15,9 @@ import SchoolIcon from '@mui/icons-material/School';
 import SearchIcon from '@mui/icons-material/Search';
 import {getMyReviewQueues, removeFromRevisionQueue} from '../api/review';
 import {useDocumentTitle} from '../hooks/useDocumentTitle';
-import useTheme from "../hooks/useTheme.js";
 import {format} from 'date-fns';
 import {fr} from 'date-fns/locale';
-import {toast, ToastContainer} from 'react-toastify';
+import {toast} from 'react-toastify';
 import {useAuth} from "../context/AuthContext.jsx";
 
 // Helper functions remain unchanged
@@ -45,7 +44,6 @@ export default function ReviewQueue() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [removing, setRemoving] = useState(null);
-  const currentTheme = useTheme();
   const {isAuthenticated} = useAuth();
   const navigate = useNavigate();
 
@@ -207,7 +205,6 @@ export default function ReviewQueue() {
           </Grid>
         ))}
       </Grid>
-      <ToastContainer position="bottom-right" theme={currentTheme === 'dark' ? 'dark' : 'light'}/>
     </Container>
   );
 }

--- a/src/pages/ReviewSession.jsx
+++ b/src/pages/ReviewSession.jsx
@@ -1,0 +1,216 @@
+import {useCallback, useEffect, useState} from 'react';
+import {useLocation, useNavigate} from 'react-router';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Container from '@mui/material/Container';
+import Divider from '@mui/material/Divider';
+import LinearProgress from '@mui/material/LinearProgress';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import {MarkdownViewer} from '../components/flashcards/flashcard';
+
+export default function ReviewSession() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const {deckTitle, selectedCards} = location.state || {};
+
+  const [randomizedCards, setRandomizedCards] = useState([]);
+  const [currentCardIndex, setCurrentCardIndex] = useState(0);
+  const [showAnswer, setShowAnswer] = useState(false);
+  const [totalScore, setTotalScore] = useState(0);
+  const [isFinished, setIsFinished] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Randomize cards on component mount
+  useEffect(() => {
+    if (selectedCards && selectedCards.length > 0) {
+      // Create a copy and shuffle the array
+      const shuffled = [...selectedCards].sort(() => Math.random() - 0.5);
+      setRandomizedCards(shuffled);
+      setIsLoading(false);
+    } else {
+      setIsLoading(false);
+    }
+  }, [selectedCards]);
+
+  const handleScoreSelection = useCallback((points) => {
+    setTotalScore(prev => prev + points);
+
+    if (currentCardIndex < randomizedCards.length - 1) {
+      setCurrentCardIndex(prev => prev + 1);
+      setShowAnswer(false);
+    } else {
+      setIsFinished(true);
+    }
+  }, [randomizedCards.length, currentCardIndex]);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.code === 'Space' && !showAnswer) {
+      setShowAnswer(true);
+      e.preventDefault();
+    } else if (showAnswer) {
+      if (e.code === 'ArrowLeft') {
+        handleScoreSelection(0); // Je ne savais pas
+      } else if (e.code === 'ArrowDown') {
+        handleScoreSelection(3); // Presque
+      } else if (e.code === 'ArrowRight') {
+        handleScoreSelection(5); // Facile
+      }
+    }
+  }, [handleScoreSelection, showAnswer]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  const handleShowAnswer = () => {
+    setShowAnswer(true);
+  };
+
+  const handleReturnToDecks = () => {
+    navigate('/review-queue');
+  };
+
+  if (!randomizedCards || randomizedCards.length === 0) {
+    if (isLoading) {
+      return (
+        <Container maxWidth="md" sx={{mt: 4}}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Chargement de la session...
+          </Typography>
+          <LinearProgress/>
+        </Container>
+      );
+    }
+
+    return (
+      <Container maxWidth="md" sx={{mt: 4}}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Session de révision invalide
+        </Typography>
+        <Typography>
+          Aucun paramètre de révision n'a été fourni. Veuillez configurer une session de révision.
+        </Typography>
+      </Container>
+    );
+  }
+
+  if (isFinished) {
+    const maxScore = randomizedCards.length * 5;
+    const scorePercentage = (totalScore / maxScore) * 100;
+
+    return (
+      <Container maxWidth="md" sx={{mt: 4}}>
+        <Paper elevation={3} sx={{p: 4, textAlign: 'center'}}>
+          <CheckCircleOutlineIcon color="success" sx={{fontSize: 60, mb: 2}}/>
+          <Typography variant="h4" gutterBottom>
+            Révision terminée !
+          </Typography>
+          <Typography variant="h6" gutterBottom>
+            Score: {totalScore} / {maxScore} ({Math.round(scorePercentage)}%)
+          </Typography>
+          <Typography color="text.secondary" sx={{mb: 3}}>
+            Vous avez révisé {randomizedCards.length} cartes.
+          </Typography>
+          <Button
+            variant="contained"
+            onClick={handleReturnToDecks}
+            startIcon={<ArrowBackIcon/>}
+          >
+            Retour à ma file de révision
+          </Button>
+        </Paper>
+      </Container>
+    );
+  }
+
+  const currentCard = randomizedCards[currentCardIndex];
+  const frontSide = currentCard?.cardSides.find(side => side.side === "front");
+  const backSide = currentCard?.cardSides.find(side => side.side === "back");
+  const frontContent = frontSide?.cardBlock?.content || "Pas de contenu";
+  const backContent = backSide?.cardBlock?.content || "Pas de contenu";
+  const progress = ((currentCardIndex) / randomizedCards.length) * 100;
+
+  return (
+    <Container maxWidth="md" sx={{mt: 4}}>
+      <Box sx={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2}}>
+        <Typography variant="h4" component="h1">
+          {deckTitle || "Session de révision"}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Carte {currentCardIndex + 1} / {randomizedCards.length}
+        </Typography>
+      </Box>
+
+      <LinearProgress variant="determinate" value={progress} sx={{mb: 4}}/>
+
+      <Card elevation={3} sx={{minHeight: 300, mb: 3}}>
+        <CardContent sx={{height: '100%', p: 4}}>
+          <Typography variant="h6" color="text.secondary" gutterBottom>
+            {showAnswer ? "Réponse" : "Question"}
+          </Typography>
+          <Divider sx={{mb: 3}}/>
+          <Box sx={{whiteSpace: 'pre-wrap'}}>
+            <MarkdownViewer source={showAnswer ? backContent : frontContent}/>
+          </Box>
+        </CardContent>
+      </Card>
+
+      {!showAnswer ? (
+        <Box sx={{display: 'flex', justifyContent: 'center', mt: 3}}>
+          <Button
+            variant="contained"
+            size="large"
+            onClick={handleShowAnswer}
+          >
+            Afficher la réponse
+          </Button>
+        </Box>
+      ) : (
+        <Stack
+          direction="row"
+          spacing={2}
+          sx={{justifyContent: 'center', mt: 3}}
+        >
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={() => handleScoreSelection(0)}
+            sx={{minWidth: 140}}
+          >
+            Je ne savais pas
+          </Button>
+          <Button
+            variant="outlined"
+            color="warning"
+            onClick={() => handleScoreSelection(3)}
+            sx={{minWidth: 140}}
+          >
+            Presque
+          </Button>
+          <Button
+            variant="outlined"
+            color="success"
+            onClick={() => handleScoreSelection(5)}
+            sx={{minWidth: 140}}
+          >
+            Facile
+          </Button>
+        </Stack>
+      )}
+
+      <Box sx={{mt: 4, textAlign: 'center'}}>
+        <Typography variant="caption" color="text.secondary">
+          Appuyez sur <strong>Espace</strong> pour afficher la réponse • Utilisez les <strong>flèches
+          directionnelles</strong> pour noter
+        </Typography>
+      </Box>
+    </Container>
+  );
+}

--- a/src/pages/ReviewSetup.jsx
+++ b/src/pages/ReviewSetup.jsx
@@ -37,34 +37,20 @@ export default function ReviewSetup() {
 
   const handleRandomSelection = (count) => {
     setRandomSelectionCount(count);
+    if (count === 0) return;
 
-    if (count === 0) {
-      // If slider is at 0, keep current selection
-      return;
-    }
-
-    // Randomly select 'count' cards from the deck
-    if (deck.cards && deck.cards.length > 0) {
+    if (deck.cards?.length) {
       const shuffled = [...deck.cards].sort(() => 0.5 - Math.random());
-      const randomCards = shuffled.slice(0, count);
-      const randomCardIds = randomCards.map(card => card.id);
-      setSelectedCards(randomCardIds);
+      setSelectedCards(shuffled.slice(0, count).map(card => card.id));
     }
   };
 
-
-  // Add this function to handle card selection
   const handleCardSelection = (cardId) => {
-    setSelectedCards(prev => {
-      if (prev.includes(cardId)) {
-        return prev.filter(id => id !== cardId);
-      } else {
-        return [...prev, cardId];
-      }
-    });
+    setSelectedCards(prev =>
+      prev.includes(cardId) ? prev.filter(id => id !== cardId) : [...prev, cardId]
+    );
   };
 
-// Modify handleStartReview to include selected cards
   const handleStartReview = () => {
     navigate('/review/session', {
       state: {
@@ -76,30 +62,20 @@ export default function ReviewSetup() {
     });
   };
 
-  // Update title based on loading state and deck data
   useDocumentTitle(
-    loading
-      ? "Chargement de la révision..."
-      : error || !deck
-        ? "Erreur - Préparation de la révision"
-        : `Révision: ${deck.title} - Configuration`
+    loading ? "Chargement de la révision..." :
+      error || !deck ? "Erreur - Préparation de la révision" :
+        `Révision: ${deck.title} - Configuration`
   );
 
-  // Redirect to login if not authenticated
   useEffect(() => {
-    if (!isAuthenticated) {
-      navigate('/login', {replace: true});
-    }
+    if (!isAuthenticated) navigate('/login', {replace: true});
   }, [isAuthenticated, navigate]);
 
-  // Redirect to decks if no deck ID is provided
   useEffect(() => {
-    if (isAuthenticated && !deckId) {
-      navigate('/decks', {replace: true});
-    }
+    if (isAuthenticated && !deckId) navigate('/decks', {replace: true});
   }, [deckId, isAuthenticated, navigate]);
 
-  // Fetch deck data
   useEffect(() => {
     if (!isAuthenticated || !deckId) return;
 
@@ -108,15 +84,10 @@ export default function ReviewSetup() {
         setLoading(true);
         const deckData = await fetchDeck(deckId);
         setDeck(deckData);
+        setCardCount(Math.min(10, deckData.card_count));
 
-        // Initialize card count to minimum of 10 or the total number of cards
-        const initialCount = Math.min(10, deckData.card_count);
-        setCardCount(initialCount);
-
-        // Pre-select all cards by default
-        if (deckData.cards && deckData.cards.length > 0) {
-          const allCardIds = deckData.cards.map(card => card.id);
-          setSelectedCards(allCardIds);
+        if (deckData.cards?.length) {
+          setSelectedCards(deckData.cards.map(card => card.id));
         }
       } catch (err) {
         console.error('Error fetching deck:', err);
@@ -129,23 +100,16 @@ export default function ReviewSetup() {
     getDeck();
   }, [deckId, isAuthenticated]);
 
-  // Render loading state
   if (!isAuthenticated) return null;
 
   if (loading) {
     return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        minHeight="60vh"
-      >
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="60vh">
         <CircularProgress aria-label="Chargement de la configuration de révision"/>
       </Box>
     );
   }
 
-  // Render error state
   if (error || !deck) {
     return (
       <Container maxWidth="md" sx={{mt: 4}}>
@@ -153,10 +117,7 @@ export default function ReviewSetup() {
           {error || "Deck non trouvé. Veuillez sélectionner un autre deck."}
         </Alert>
         <Box mt={2}>
-          <Button
-            variant="contained"
-            onClick={() => navigate('/review-queue')}
-          >
+          <Button variant="contained" onClick={() => navigate('/review-queue')}>
             Retour à ma file de révision
           </Button>
         </Box>
@@ -170,7 +131,6 @@ export default function ReviewSetup() {
         Configuration de la révision
       </Typography>
 
-
       <Box mb={4}>
         <DeckPreviewCard deck={deck} showSeeButton={false} transition={false}/>
       </Box>
@@ -181,33 +141,22 @@ export default function ReviewSetup() {
           <Box sx={{display: 'flex', justifyContent: 'flex-start', gap: 2, mt: 1}}>
             <Tooltip
               title='Affiche le recto de la carte ; appuyez sur "Afficher la réponse" ou la barre espace pour révéler le verso, puis notez votre réponse.'
-              arrow
-              placement="top"
-            >
+              arrow placement="top">
               <Button
                 variant={mode === 'flashcard' ? 'contained' : 'outlined'}
-                color="primary"
                 onClick={() => setMode('flashcard')}
                 sx={{width: '150px'}}
               >
                 Flashcards
               </Button>
             </Tooltip>
-            <Tooltip
-              title="En développement"
-              arrow
-              placement="top"
-            >
-              <span> {/* Wrapper needed for disabled buttons */}
+            <Tooltip title="En développement" arrow placement="top">
+              <span>
                 <Button
                   variant={mode === 'qcm' ? 'contained' : 'outlined'}
-                  color="primary"
                   onClick={() => setMode('qcm')}
                   disabled
-                  sx={{
-                    width: '150px',
-                    opacity: 0.6
-                  }}
+                  sx={{width: '150px', opacity: 0.6}}
                 >
                   QCM
                 </Button>
@@ -264,7 +213,6 @@ export default function ReviewSetup() {
                 {deck.cards?.map((card, index) => {
                   const frontSide = card.cardSides.find(side => side.side === "front");
                   const backSide = card.cardSides.find(side => side.side === "back");
-
                   const frontContent = frontSide?.cardBlock?.content || "";
                   const backContent = backSide?.cardBlock?.content || null;
 

--- a/src/pages/ReviewSetup.jsx
+++ b/src/pages/ReviewSetup.jsx
@@ -58,12 +58,17 @@ export default function ReviewSetup() {
   };
 
   const handleStartReview = () => {
+    // Only include selected cards with their full data structure
+    const selectedCardsData = deck.cards.filter(card =>
+      selectedCards.includes(card.id)
+    );
+
     navigate('/review/session', {
       state: {
+        mode: mode,
         deckId,
-        cardCount,
-        mode,
-        selectedCardIds: selectedCards.length > 0 ? selectedCards : null
+        deckTitle: deck.title,
+        selectedCards: selectedCardsData
       }
     });
   };

--- a/src/pages/ReviewSetup.jsx
+++ b/src/pages/ReviewSetup.jsx
@@ -34,6 +34,7 @@ export default function ReviewSetup() {
   const [selectedCards, setSelectedCards] = useState([]);
   const [randomSelectionCount, setRandomSelectionCount] = useState(0);
   const [showCards, setShowCards] = useState(true);
+  const [eligibleCardsCount, setEligibleCardsCount] = useState(0);
 
   const handleRandomSelection = (count) => {
     setRandomSelectionCount(count);
@@ -72,6 +73,17 @@ export default function ReviewSetup() {
       error || !deck ? "Erreur - Préparation de la révision" :
         `Révision: ${deck.title} - Configuration`
   );
+
+  // calculate and cache eligible cards count
+  useEffect(() => {
+    if (!deck?.cards) return;
+
+    const eligibleCardsCount = mode === 'flashcard'
+      ? deck.cards.filter(card => card.cardSides.some(side => side.side === "back")).length
+      : deck.cards.length;
+
+    setEligibleCardsCount(eligibleCardsCount);
+  }, [deck?.cards, mode]);
 
   useEffect(() => {
     if (!isAuthenticated) navigate('/login', {replace: true});
@@ -192,17 +204,13 @@ export default function ReviewSetup() {
               onChange={(_, newValue) => setRandomSelectionCount(newValue)}
               onChangeCommitted={(_, newValue) => handleRandomSelection(newValue)}
               min={0}
-              max={mode === 'flashcard'
-                ? deck.cards?.filter(card => card.cardSides.some(side => side.side === "back"))?.length || 0
-                : deck.cards?.length || 10}
+              max={eligibleCardsCount || 0}
               valueLabelDisplay="auto"
               aria-labelledby="random-selection-slider"
               sx={{mx: 2}}
             />
             <Typography variant="body2" sx={{minWidth: '35px'}}>
-              {mode === 'flashcard'
-                ? deck.cards?.filter(card => card.cardSides.some(side => side.side === "back"))?.length || 0
-                : deck.cards?.length || 0}
+              {eligibleCardsCount || 0}
             </Typography>
           </Box>
           <Typography variant="caption" color="text.secondary">

--- a/src/pages/ReviewSetup.jsx
+++ b/src/pages/ReviewSetup.jsx
@@ -258,7 +258,7 @@ export default function ReviewSetup() {
             size="large"
             onClick={handleStartReview}
             startIcon={<PlayArrowIcon/>}
-            disabled={deck.card_count === 0}
+            disabled={deck.card_count === 0 || selectedCards.length === 0}
           >
             Commencer la révision
           </Button>

--- a/src/pages/ReviewSetup.jsx
+++ b/src/pages/ReviewSetup.jsx
@@ -1,0 +1,321 @@
+import {useEffect, useState} from 'react';
+import {useNavigate, useSearchParams} from 'react-router';
+import {useDocumentTitle} from '../hooks/useDocumentTitle';
+import {useAuth} from '../context/AuthContext';
+import {fetchDeck} from '../api/deck';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import FormControl from '@mui/material/FormControl';
+import FormLabel from '@mui/material/FormLabel';
+import Button from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import Grid from '@mui/material/Grid'
+import Tooltip from '@mui/material/Tooltip';
+import DeckPreviewCard from "../components/deck/DeckPreviewCard.jsx";
+import OutlinedCard from "../components/flashcards/flashcard.jsx";
+import Slider from '@mui/material/Slider';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import IconButton from '@mui/material/IconButton';
+
+export default function ReviewSetup() {
+  const [searchParams] = useSearchParams();
+  const deckId = searchParams.get('deck');
+  const navigate = useNavigate();
+  const {isAuthenticated} = useAuth();
+  const [deck, setDeck] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [mode, setMode] = useState('flashcard');
+  const [cardCount, setCardCount] = useState(10);
+  const [selectedCards, setSelectedCards] = useState([]);
+  const [randomSelectionCount, setRandomSelectionCount] = useState(0);
+  const [showCards, setShowCards] = useState(true);
+
+  const handleRandomSelection = (count) => {
+    setRandomSelectionCount(count);
+
+    if (count === 0) {
+      // If slider is at 0, keep current selection
+      return;
+    }
+
+    // Randomly select 'count' cards from the deck
+    if (deck.cards && deck.cards.length > 0) {
+      const shuffled = [...deck.cards].sort(() => 0.5 - Math.random());
+      const randomCards = shuffled.slice(0, count);
+      const randomCardIds = randomCards.map(card => card.id);
+      setSelectedCards(randomCardIds);
+    }
+  };
+
+
+  // Add this function to handle card selection
+  const handleCardSelection = (cardId) => {
+    setSelectedCards(prev => {
+      if (prev.includes(cardId)) {
+        return prev.filter(id => id !== cardId);
+      } else {
+        return [...prev, cardId];
+      }
+    });
+  };
+
+// Modify handleStartReview to include selected cards
+  const handleStartReview = () => {
+    navigate('/review/session', {
+      state: {
+        deckId,
+        cardCount,
+        mode,
+        selectedCardIds: selectedCards.length > 0 ? selectedCards : null
+      }
+    });
+  };
+
+  // Update title based on loading state and deck data
+  useDocumentTitle(
+    loading
+      ? "Chargement de la révision..."
+      : error || !deck
+        ? "Erreur - Préparation de la révision"
+        : `Révision: ${deck.title} - Configuration`
+  );
+
+  // Redirect to login if not authenticated
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate('/login', {replace: true});
+    }
+  }, [isAuthenticated, navigate]);
+
+  // Redirect to decks if no deck ID is provided
+  useEffect(() => {
+    if (isAuthenticated && !deckId) {
+      navigate('/decks', {replace: true});
+    }
+  }, [deckId, isAuthenticated, navigate]);
+
+  // Fetch deck data
+  useEffect(() => {
+    if (!isAuthenticated || !deckId) return;
+
+    const getDeck = async () => {
+      try {
+        setLoading(true);
+        const deckData = await fetchDeck(deckId);
+        setDeck(deckData);
+
+        // Initialize card count to minimum of 10 or the total number of cards
+        const initialCount = Math.min(10, deckData.card_count);
+        setCardCount(initialCount);
+
+        // Pre-select all cards by default
+        if (deckData.cards && deckData.cards.length > 0) {
+          const allCardIds = deckData.cards.map(card => card.id);
+          setSelectedCards(allCardIds);
+        }
+      } catch (err) {
+        console.error('Error fetching deck:', err);
+        setError('Impossible de charger le deck. Veuillez réessayer plus tard.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getDeck();
+  }, [deckId, isAuthenticated]);
+
+  // Render loading state
+  if (!isAuthenticated) return null;
+
+  if (loading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="60vh"
+      >
+        <CircularProgress aria-label="Chargement de la configuration de révision"/>
+      </Box>
+    );
+  }
+
+  // Render error state
+  if (error || !deck) {
+    return (
+      <Container maxWidth="md" sx={{mt: 4}}>
+        <Alert severity="error">
+          {error || "Deck non trouvé. Veuillez sélectionner un autre deck."}
+        </Alert>
+        <Box mt={2}>
+          <Button
+            variant="contained"
+            onClick={() => navigate('/review-queue')}
+          >
+            Retour à ma file de révision
+          </Button>
+        </Box>
+      </Container>
+    );
+  }
+
+  return (
+    <Container maxWidth="md" sx={{mt: 4, mb: 6}}>
+      <Typography variant="h4" component="h1" gutterBottom>
+        Configuration de la révision
+      </Typography>
+
+
+      <Box mb={4}>
+        <DeckPreviewCard deck={deck} showSeeButton={false} transition={false}/>
+      </Box>
+
+      <Box component="form" sx={{mb: 4}}>
+        <FormControl component="fieldset" sx={{mb: 4, width: '100%'}}>
+          <FormLabel component="legend">Mode de révision</FormLabel>
+          <Box sx={{display: 'flex', justifyContent: 'flex-start', gap: 2, mt: 1}}>
+            <Tooltip
+              title='Affiche le recto de la carte ; appuyez sur "Afficher la réponse" ou la barre espace pour révéler le verso, puis notez votre réponse.'
+              arrow
+              placement="top"
+            >
+              <Button
+                variant={mode === 'flashcard' ? 'contained' : 'outlined'}
+                color="primary"
+                onClick={() => setMode('flashcard')}
+                sx={{width: '150px'}}
+              >
+                Flashcards
+              </Button>
+            </Tooltip>
+            <Tooltip
+              title="En développement"
+              arrow
+              placement="top"
+            >
+              <span> {/* Wrapper needed for disabled buttons */}
+                <Button
+                  variant={mode === 'qcm' ? 'contained' : 'outlined'}
+                  color="primary"
+                  onClick={() => setMode('qcm')}
+                  disabled
+                  sx={{
+                    width: '150px',
+                    opacity: 0.6
+                  }}
+                >
+                  QCM
+                </Button>
+              </span>
+            </Tooltip>
+          </Box>
+        </FormControl>
+
+        <Box sx={{mt: 2, mb: 4}}>
+          <Typography variant="body2" gutterBottom>
+            Sélection aléatoire de cartes
+          </Typography>
+          <Box sx={{display: 'flex', alignItems: 'center', gap: 2}}>
+            <Typography variant="body2" sx={{minWidth: '20px'}}>
+              {randomSelectionCount}
+            </Typography>
+            <Slider
+              value={randomSelectionCount}
+              onChange={(_, newValue) => setRandomSelectionCount(newValue)}
+              onChangeCommitted={(_, newValue) => handleRandomSelection(newValue)}
+              min={0}
+              max={deck.cards?.length || 10}
+              valueLabelDisplay="auto"
+              aria-labelledby="random-selection-slider"
+              sx={{mx: 2}}
+            />
+            <Typography variant="body2" sx={{minWidth: '35px'}}>
+              {deck.cards?.length || 0}
+            </Typography>
+          </Box>
+          <Typography variant="caption" color="text.secondary">
+            Déplacez le curseur pour sélectionner aléatoirement un nombre de fiches (0 = sélection manuelle)
+          </Typography>
+        </Box>
+
+        <FormControl sx={{mb: 4, width: '100%'}}>
+          <Box sx={{display: 'flex', alignItems: 'center', mb: 2}}>
+            <FormLabel component="legend">
+              Sélectionnez les fiches à réviser
+            </FormLabel>
+            <IconButton
+              size="small"
+              onClick={() => setShowCards(prev => !prev)}
+              aria-label={showCards ? "Masquer les fiches" : "Afficher les fiches"}
+              sx={{ml: 1}}
+            >
+              {showCards ? <ExpandLessIcon/> : <ExpandMoreIcon/>}
+            </IconButton>
+          </Box>
+
+          {showCards && (
+            <Box sx={{mb: 3}}>
+              <Grid container spacing={2}>
+                {deck.cards?.map((card, index) => {
+                  const frontSide = card.cardSides.find(side => side.side === "front");
+                  const backSide = card.cardSides.find(side => side.side === "back");
+
+                  const frontContent = frontSide?.cardBlock?.content || "";
+                  const backContent = backSide?.cardBlock?.content || null;
+
+                  return (
+                    <Grid item xs={12} sm={6} md={4} key={card.id || index}>
+                      <Box
+                        sx={{
+                          cursor: 'pointer',
+                          border: selectedCards.includes(card.id) ? '2px solid' : '',
+                          borderColor: selectedCards.includes(card.id) ? 'primary.main' : 'divider',
+                          transition: 'all 0.2s',
+                          height: '100%',
+                          '&:hover': {
+                            borderColor: 'primary.main',
+                            transform: 'translateY(-2px)'
+                          }
+                        }}
+                        onClick={() => handleCardSelection(card.id)}
+                      >
+                        <OutlinedCard
+                          sujet={deck.title}
+                          description_recto={frontContent}
+                          description_verso={backContent}
+                          sx={{backgroundColor: selectedCards.includes(card.id) ? 'action.selected' : 'background.paper'}}
+                        />
+                      </Box>
+                    </Grid>
+                  );
+                })}
+              </Grid>
+            </Box>
+          )}
+
+          <FormLabel id="card-count-label" sx={{mt: 3}}>
+            Nombre de fiches à réviser: {selectedCards.length}
+          </FormLabel>
+        </FormControl>
+
+        <Box display="flex" justifyContent="center" mt={4}>
+          <Button
+            variant="contained"
+            color="primary"
+            size="large"
+            onClick={handleStartReview}
+            startIcon={<PlayArrowIcon/>}
+            disabled={deck.card_count === 0}
+          >
+            Commencer la révision
+          </Button>
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -17,6 +17,7 @@ import About from './pages/About.jsx'
 import MyDecks from './pages/MyDecks.jsx'
 import ReviewQueue from './pages/ReviewQueue.jsx';
 import ReviewSetup from './pages/ReviewSetup.jsx';
+import ReviewSession from './pages/ReviewSession.jsx';
 
 export const router = createBrowserRouter([{
   path: '/',
@@ -53,7 +54,7 @@ export const router = createBrowserRouter([{
       path: 'review',
       children: [
         {index: true, Component: ReviewSetup},
-        {path: 'session', Component: NotFound /* TODO: review session page */},
+        {path: 'session', Component: ReviewSession},
       ]
     },
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -16,6 +16,7 @@ import LegalTerms from './pages/LegalTerms.jsx'
 import About from './pages/About.jsx'
 import MyDecks from './pages/MyDecks.jsx'
 import ReviewQueue from './pages/ReviewQueue.jsx';
+import ReviewSetup from './pages/ReviewSetup.jsx';
 
 export const router = createBrowserRouter([{
   path: '/',
@@ -34,7 +35,6 @@ export const router = createBrowserRouter([{
     {path: '/legal/terms', Component: LegalTerms},
     {path: '/about', Component: About},
     {path: '/my-decks', Component: MyDecks},
-    { path: '/review-queue', Component: ReviewQueue },
 
     /* --------- Decks --------- */
     {
@@ -43,7 +43,17 @@ export const router = createBrowserRouter([{
         {index: true, Component: DeckGallery},
         {path: 'new', Component: DeckForm},
         {path: ':id', Component: DeckDetails},
-        {path: ':id/edit', Component: DeckForm /* TODO: DeckEdit  */}
+        {path: ':id/edit', Component: DeckForm}
+      ]
+    },
+
+    /* --------- Révisions --------- */
+    { path: '/review-queue', Component: ReviewQueue },
+    {
+      path: 'review',
+      children: [
+        {index: true, Component: ReviewSetup},
+        {path: 'session', Component: NotFound /* TODO: review session page */},
       ]
     },
 


### PR DESCRIPTION
Cette PR ajoute la page de révision `/review?deck=id`.

Pour l'instant un seul mode de révision existe: `flashcards` qui fonctionne comme anki et nécessite les cartes d'être recto-verso.
C'est de l'auto-évaluation et cela n'a aucun impact dans le backend, toute la révision est gérée niveau client.

**QOL changes:**

- Le component `flashcard.jsx` est plus customisable
- Les toast sont mis niveau `Root.jsx` ce qui permet de garder les notifs sur l'écran en changement de page et de ne plus avoir a importer le `ToastContainer` dans toutes les pages.